### PR TITLE
hotfix: fix the bucket prefix

### DIFF
--- a/scripts/bucket_file_count.py
+++ b/scripts/bucket_file_count.py
@@ -38,7 +38,7 @@ s3 = boto3.resource(
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
 key = os.getenv('STORAGE_LOCATION_KEY')
-if(key):
+if key:
     prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/"
 else: 
     prefix = year + "/" + month + "/" + datetime_str + "/"

--- a/scripts/bucket_file_count.py
+++ b/scripts/bucket_file_count.py
@@ -37,7 +37,11 @@ s3 = boto3.resource(
 )
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
-prefix = os.getenv('STORAGE_LOCATION_KEY') + "/" + year + "/" + month + "/" + datetime_str + "/"
+key = os.getenv('STORAGE_LOCATION_KEY')
+if(key):
+    prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/"
+else: 
+    prefix = year + "/" + month + "/" + datetime_str + "/"
 
 file_count = 0
 latest = dt.datetime(1, 1, 1, tzinfo=dt.timezone.utc)

--- a/scripts/db_file_count.py
+++ b/scripts/db_file_count.py
@@ -42,7 +42,7 @@ s3 = boto3.resource(
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
 key = os.getenv('STORAGE_LOCATION_KEY')
-if(key):
+if key:
     prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/"
 else: 
     prefix = year + "/" + month + "/" + datetime_str + "/"

--- a/scripts/db_file_count.py
+++ b/scripts/db_file_count.py
@@ -41,8 +41,12 @@ s3 = boto3.resource(
 )
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
-prefix = os.getenv('STORAGE_LOCATION_KEY') + "/" + year + "/" + month + "/" + datetime_str + "/"
-
+key = os.getenv('STORAGE_LOCATION_KEY')
+if(key):
+    prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/"
+else: 
+    prefix = year + "/" + month + "/" + datetime_str + "/"
+    
 file_type = 'all_files_example'
 
 file_count = 0

--- a/scripts/db_inc_logs.py
+++ b/scripts/db_inc_logs.py
@@ -62,7 +62,7 @@ s3 = boto3.resource(
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
 key = os.getenv('STORAGE_LOCATION_KEY')
-if(key):
+if key:
     prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/" + "logs/"
 else: 
     prefix = year + "/" + month + "/" + datetime_str + "/" + "logs/"

--- a/scripts/db_inc_logs.py
+++ b/scripts/db_inc_logs.py
@@ -11,7 +11,7 @@ the script. score-db makes the harvesting call, translates, and stores the data 
 This script assumes that the statistics and variables provided are already registered as metric types.
 
 This script relies on environment variables for the S3 bucket and the location of the score-db executable.
-Folder structure is assumed to be KEY/%Y/%M/CYCLE.
+Folder structure is assumed to be KEY/%Y/%M/CYCLE/logs.
 """
 import sys
 import boto3
@@ -61,7 +61,11 @@ s3 = boto3.resource(
 )
 
 bucket = s3.Bucket(os.getenv('STORAGE_LOCATION_BUCKET'))
-prefix = os.getenv('STORAGE_LOCATION_KEY') + "/" + year + "/" + month + "/" + datetime_str + "/" + "logs/"
+key = os.getenv('STORAGE_LOCATION_KEY')
+if(key):
+    prefix = key + "/" + year + "/" + month + "/" + datetime_str + "/" + "logs/"
+else: 
+    prefix = year + "/" + month + "/" + datetime_str + "/" + "logs/"
 
 
 #harvester is built to handle one file at a time so make calls per listed file 


### PR DESCRIPTION
A problem was found if the STORAGE_LOCATION_KEY was empty, as is allowable, then the prefix was not being created for the bucket correctly with an extra '/'. This has been removed for this case with an if else statement where these cases occurred. The new code has been tested to handle both scenarios successfully. 