### PR TITLE
metric type registration improvement

### DIFF
--- a/scripts/db-registration.py
+++ b/scripts/db-registration.py
@@ -71,14 +71,15 @@ def register_file_type():
 def register_metric_type():
     #USER DEFINED VARIABLES
     name = "metric_name"
+    long_name = "Long name of metric"
     measurement_type = "measurement_type"
     units = "measurement_units"
     stat_type = "stat_type"
-    description = "the description of the metric type"
+    description = json.dumps({"type_description": "description information"})
     #END USER DEFINED VARIABLES
 
     print(f'begin registering metric type: {name}')
-    yaml_file = db_yaml_generator.generate_metric_type_reg_yaml(name, measurement_type, units, stat_type, description)
+    yaml_file = db_yaml_generator.generate_metric_type_reg_yaml(name, long_name, measurement_type, units, stat_type, description)
     subprocess.run(["python3", os.getenv("SCORE_DB_BASE_LOCATION"), yaml_file])
     os.remove(yaml_file)
     print(f'end registering metric type')

--- a/scripts/db_yaml_generator.py
+++ b/scripts/db_yaml_generator.py
@@ -144,7 +144,7 @@ def generate_harvest_metrics_yaml(experiment_name, experiment_wallclock, hv_tran
         yaml.dump(body, outfile)
     return yaml_file_path
  
-def generate_metric_type_reg_yaml(name, measurement_type, units, stat_type, description):
+def generate_metric_type_reg_yaml(name, long_name, measurement_type, units, stat_type, description):
     yaml_file_path = os.path.join(PY_CURRENT_DIR, YAML_FILE_PREFIX + dt.datetime.now().strftime("%Y%m%d%H%M%S") + '-metric_type.yaml')
     
     body = {
@@ -152,10 +152,11 @@ def generate_metric_type_reg_yaml(name, measurement_type, units, stat_type, desc
         'method': 'PUT',
         'body' : {
             'name': name,
+            'long_name': long_name,
             'measurement_type': measurement_type,
             'measurement_units': units,
             'stat_type': stat_type,
-            'description': json.dumps({"type_description": description})
+            'description': description
         }
     }
 


### PR DESCRIPTION
Add long_name for metric types to registration step in monitoring. move json dump for description to user defined section given expectation of more description fields may need to be customized for info to make it easier for user to have multiple items in the field (such as could've been the case with long_name). 

Depends on https://github.com/NOAA-PSL/score-db/pull/25 in score-db for using the new long_name features. 